### PR TITLE
Move contributing rules to CONTRIBUTING.MD

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,8 @@
+## Guidelines for contributing
+
+Thank you for your interest in contributing! We're always happy to get the community involved in our projects, however we have just a couple rules that we enforce for any pull requests:
+
+  - You must follow the code style already in place
+  - You must squash all of your commits into one meaningful commit
+
+Any pull request that does not meet the above criteria will not be merged.

--- a/README.md
+++ b/README.md
@@ -63,15 +63,6 @@ ReLinker.loadLibrary(context, "mylibrary");
 
 See the sample application under `sample/` for a quick demo.
 
-## Contributing
-
-Thank you for your interest in contributing! We're always happy to get the community involved in our projects, however we have just a couple rules that we enforce for any pull requests:
-
-  - You must follow the code style already in place
-  - You must squash all of your commits into one meaningful commit
-
-Any pull request that does not meet the above criteria will not be merged.
-
 ## License
 
     Copyright 2015 KeepSafe Inc.


### PR DESCRIPTION
This enables Github's UI for reminding contributors what the guidelines are, per their blog post:
https://help.github.com/articles/setting-guidelines-for-repository-contributors/