### PR TITLE
Remove dependency on android.text.TextUtils

### DIFF
--- a/relinker/src/main/java/com/getkeepsafe/relinker/ReLinkerInstance.java
+++ b/relinker/src/main/java/com/getkeepsafe/relinker/ReLinkerInstance.java
@@ -16,7 +16,6 @@
 package com.getkeepsafe.relinker;
 
 import android.content.Context;
-import android.text.TextUtils;
 import android.util.Log;
 
 import com.getkeepsafe.relinker.elf.ElfParser;

--- a/relinker/src/main/java/com/getkeepsafe/relinker/ReLinkerInstance.java
+++ b/relinker/src/main/java/com/getkeepsafe/relinker/ReLinkerInstance.java
@@ -23,13 +23,10 @@ import com.getkeepsafe.relinker.elf.ElfParser;
 import java.io.File;
 import java.io.FilenameFilter;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 
 public class ReLinkerInstance {
     private static final String LIB_DIR = "lib";

--- a/relinker/src/main/java/com/getkeepsafe/relinker/TextUtils.java
+++ b/relinker/src/main/java/com/getkeepsafe/relinker/TextUtils.java
@@ -1,0 +1,18 @@
+package com.getkeepsafe.relinker;
+
+/**
+ * Slimmed down version of https://developer.android.com/reference/android/text/TextUtils.html to
+ * avoid depending on android.text.TextUtils.
+ */
+final class TextUtils {
+
+    /**
+     * Returns true if the string is null or 0-length.
+     *
+     * @param str the string to be examined
+     * @return true if str is null or zero length
+     */
+    public static boolean isEmpty(CharSequence str) {
+        return str == null || str.length() == 0;
+    }
+}


### PR DESCRIPTION
If ReLinker is run in an environment where the Android APIs are provided by roboeletrict, android.text.TextUtils.isEmpty() would throw a roboteletric "Stub!" RuntimeException. 

This changeset removes the dependency on android.text.TextUtils.
