### PR TITLE
Search library also in split APKs.

### DIFF
--- a/relinker/src/main/java/com/getkeepsafe/relinker/ApkLibraryInstaller.java
+++ b/relinker/src/main/java/com/getkeepsafe/relinker/ApkLibraryInstaller.java
@@ -17,6 +17,7 @@ package com.getkeepsafe.relinker;
 
 import android.content.Context;
 import android.content.pm.ApplicationInfo;
+import android.os.Build;
 
 import java.io.Closeable;
 import java.io.File;
@@ -32,6 +33,74 @@ public class ApkLibraryInstaller implements ReLinker.LibraryInstaller {
     private static final int MAX_TRIES = 5;
     private static final int COPY_BUFFER_SIZE = 4096;
 
+    private String[] sourceDirectories(final Context context) {
+        final ApplicationInfo appInfo = context.getApplicationInfo();
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP &&
+            appInfo.splitSourceDirs != null &&
+            appInfo.splitSourceDirs.length != 0) {
+            String[] apks = new String[appInfo.splitSourceDirs.length + 1];
+            apks[0] = appInfo.sourceDir;
+            System.arraycopy(appInfo.splitSourceDirs, 0, apks, 1, appInfo.splitSourceDirs.length);
+            return apks;
+        } else {
+            return new String[] { appInfo.sourceDir };
+        }
+    }
+
+    private static class ZipFileInZipEntry {
+        public ZipFile zipFile;
+        public ZipEntry zipEntry;
+
+        public ZipFileInZipEntry(ZipFile zipFile, ZipEntry zipEntry) {
+            this.zipFile = zipFile;
+            this.zipEntry = zipEntry;
+        }
+    }
+
+    private ZipFileInZipEntry findAPKWithLibrary(final Context context,
+                                                       final String[] abis,
+                                                       final String mappedLibraryName,
+                                                       final ReLinkerInstance instance) {
+
+        ZipFile zipFile = null;
+        for (String sourceDir : sourceDirectories(context)) {
+            int tries = 0;
+            while (tries++ < MAX_TRIES) {
+                try {
+                    zipFile = new ZipFile(new File(sourceDir), ZipFile.OPEN_READ);
+                    break;
+                } catch (IOException ignored) {
+                }
+            }
+
+            if (zipFile == null) {
+                continue;
+            }
+
+            tries = 0;
+            while (tries++ < MAX_TRIES) {
+                String jniNameInApk = null;
+                ZipEntry libraryEntry = null;
+
+                for (final String abi : abis) {
+                    jniNameInApk = "lib" + File.separatorChar + abi + File.separatorChar
+                            + mappedLibraryName;
+
+                    instance.log("Looking for %s in APK %s...", jniNameInApk, sourceDir);
+
+                    libraryEntry = zipFile.getEntry(jniNameInApk);
+
+                    if (libraryEntry != null) {
+                        return new ZipFileInZipEntry(zipFile, libraryEntry);
+                    }
+                }
+            }
+        }
+
+        return null;
+    }
+
     /**
      * Attempts to unpack the given library to the given destination. Implements retry logic for
      * IO operations to ensure they succeed.
@@ -46,49 +115,17 @@ public class ApkLibraryInstaller implements ReLinker.LibraryInstaller {
                                final String mappedLibraryName,
                                final File destination,
                                final ReLinkerInstance instance) {
-        ZipFile zipFile = null;
+        ZipFileInZipEntry found = null;
         try {
-            final ApplicationInfo appInfo = context.getApplicationInfo();
+            found = findAPKWithLibrary(context, abis, mappedLibraryName, instance);
+            if (found == null) {
+                // Does not exist in any APK
+                throw new MissingLibraryException(mappedLibraryName);
+            }
+
             int tries = 0;
             while (tries++ < MAX_TRIES) {
-                try {
-                    zipFile = new ZipFile(new File(appInfo.sourceDir), ZipFile.OPEN_READ);
-                    break;
-                } catch (IOException ignored) {}
-            }
-
-            if (zipFile == null) {
-                instance.log("FATAL! Couldn't find application APK!");
-                return;
-            }
-
-            tries = 0;
-            while (tries++ < MAX_TRIES) {
-                String jniNameInApk = null;
-                ZipEntry libraryEntry = null;
-
-                for (final String abi : abis) {
-                    jniNameInApk = "lib" + File.separatorChar + abi + File.separatorChar
-                            + mappedLibraryName;
-                    libraryEntry = zipFile.getEntry(jniNameInApk);
-
-                    if (libraryEntry != null) {
-                        break;
-                    }
-                }
-
-                if (jniNameInApk != null) instance.log("Looking for %s in APK...", jniNameInApk);
-
-                if (libraryEntry == null) {
-                    // Does not exist in the APK
-                    if (jniNameInApk != null) {
-                        throw new MissingLibraryException(jniNameInApk);
-                    } else {
-                        throw new MissingLibraryException(mappedLibraryName);
-                    }
-                }
-
-                instance.log("Found %s! Extracting...", jniNameInApk);
+                instance.log("Found %s! Extracting...", mappedLibraryName);
                 try {
                     if (!destination.exists() && !destination.createNewFile()) {
                         continue;
@@ -101,7 +138,7 @@ public class ApkLibraryInstaller implements ReLinker.LibraryInstaller {
                 InputStream inputStream = null;
                 FileOutputStream fileOut = null;
                 try {
-                    inputStream = zipFile.getInputStream(libraryEntry);
+                    inputStream = found.zipFile.getInputStream(found.zipEntry);
                     fileOut = new FileOutputStream(destination);
                     final long written = copy(inputStream, fileOut);
                     fileOut.getFD().sync();
@@ -130,8 +167,8 @@ public class ApkLibraryInstaller implements ReLinker.LibraryInstaller {
             instance.log("FATAL! Couldn't extract the library from the APK!");
         } finally {
             try {
-                if (zipFile != null) {
-                    zipFile.close();
+                if (found != null && found.zipFile != null) {
+                    found.zipFile.close();
                 }
             } catch (IOException ignored) {}
         }


### PR DESCRIPTION
The library may be placed in a split APK. This happens for example when using
the dynamic delivery.

Fixes #44.