### PR TITLE
Fix resource leak

### DIFF
--- a/relinker/src/main/java/com/getkeepsafe/relinker/ApkLibraryInstaller.java
+++ b/relinker/src/main/java/com/getkeepsafe/relinker/ApkLibraryInstaller.java
@@ -59,9 +59,9 @@ public class ApkLibraryInstaller implements ReLinker.LibraryInstaller {
     }
 
     private ZipFileInZipEntry findAPKWithLibrary(final Context context,
-                                                       final String[] abis,
-                                                       final String mappedLibraryName,
-                                                       final ReLinkerInstance instance) {
+                                                 final String[] abis,
+                                                 final String mappedLibraryName,
+                                                 final ReLinkerInstance instance) {
 
         ZipFile zipFile = null;
         for (String sourceDir : sourceDirectories(context)) {
@@ -95,6 +95,11 @@ public class ApkLibraryInstaller implements ReLinker.LibraryInstaller {
                         return new ZipFileInZipEntry(zipFile, libraryEntry);
                     }
                 }
+            }
+
+            try {
+                zipFile.close();
+            } catch (IOException ignored) {
             }
         }
 


### PR DESCRIPTION
- From StrictMode policy violation:

```
android.os.strictmode.LeakedClosableViolation:
   A resource was acquired at attached stack trace but never released.
   See java.io.Closeable for information on avoiding resource leaks.

        at android.os.StrictMode$AndroidCloseGuardReporter.report(StrictMode.java:1786)
        at dalvik.system.CloseGuard.warnIfOpen(CloseGuard.java:264)
        at java.util.zip.ZipFile.finalize(ZipFile.java:705)
        at java.lang.Daemons$FinalizerDaemon.doFinalize(Daemons.java:250)
        at java.lang.Daemons$FinalizerDaemon.runInternal(Daemons.java:237)
        at java.lang.Daemons$Daemon.run(Daemons.java:103)
        at java.lang.Thread.run(Thread.java:764)
     Caused by: java.lang.Throwable: Explicit termination method 'close' not called
        at dalvik.system.CloseGuard.open(CloseGuard.java:221)
        at java.util.zip.ZipFile.<init>(ZipFile.java:247)
        at java.util.zip.ZipFile.<init>(ZipFile.java:152)
        at com.getkeepsafe.relinker.ApkLibraryInstaller.findAPKWithLibrary(ApkLibraryInstaller.java:71)
        at com.getkeepsafe.relinker.ApkLibraryInstaller.installLibrary(ApkLibraryInstaller.java:120)
        at com.getkeepsafe.relinker.ReLinkerInstance.loadLibraryInternal(ReLinkerInstance.java:180)
        at com.getkeepsafe.relinker.ReLinkerInstance.loadLibrary(ReLinkerInstance.java:136)
        at com.getkeepsafe.relinker.ReLinker.loadLibrary(ReLinker.java:70)
        at com.getkeepsafe.relinker.ReLinker.loadLibrary(ReLinker.java:51)
```