### PR TITLE
Don't do operations on a closed `ZipFile`

### DIFF
--- a/relinker/src/main/java/com/getkeepsafe/relinker/ApkLibraryInstaller.java
+++ b/relinker/src/main/java/com/getkeepsafe/relinker/ApkLibraryInstaller.java
@@ -68,8 +68,8 @@ public class ApkLibraryInstaller implements ReLinker.LibraryInstaller {
                                                  final String mappedLibraryName,
                                                  final ReLinkerInstance instance) {
 
-        ZipFile zipFile = null;
         for (String sourceDir : sourceDirectories(context)) {
+            ZipFile zipFile = null;
             int tries = 0;
             while (tries++ < MAX_TRIES) {
                 try {


### PR DESCRIPTION
When zip file was opened inside the loop and it did not contain the lib
inside of it, the `zipFile` stayed non-`null` for all next iterations. This
can cause next iterations that fail to open zip file to access
previously already closed `zipFile` because `zipFile == null` will never
be true.

Fixed by moving the `zipFile` declaration inside of the loop.