### PR TITLE
Release 1.4.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A robust native library loader for Android. More information can be found in our
 
  **Min SDK:** 9
  
- [JavaDoc](https://jitpack.io/com/github/KeepSafe/Relinker/1.4.0/javadoc/overview-summary.html)
+ [JavaDoc](https://jitpack.io/com/github/KeepSafe/Relinker/1.4.1/javadoc/overview-summary.html)
 
 ## Overview
 
@@ -51,7 +51,7 @@ ReLinker is distributed using [jcenter](https://bintray.com/keepsafesoftware/And
    }
    
    dependencies {
-         compile 'com.getkeepsafe.relinker:relinker:1.4.0'
+         compile 'com.getkeepsafe.relinker:relinker:1.4.1'
    }
 ```
 

--- a/relinker/build.gradle
+++ b/relinker/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'com.github.dcendents.android-maven'
 apply plugin: 'com.jfrog.bintray'
 
 group = 'com.getkeepsafe.relinker'
-version = '1.4.0'
+version = '1.4.1'
 
 android {
     compileSdkVersion 28


### PR DESCRIPTION
Changes:
* Version bumped for release

Includes
* https://github.com/KeepSafe/ReLinker/pull/72
* https://github.com/KeepSafe/ReLinker/pull/68

Addresses:
* https://github.com/KeepSafe/ReLinker/issues/64
* https://github.com/KeepSafe/ReLinker/issues/71