### PR TITLE
Move artifact publishing from JCenter to Maven Central

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,4 +10,4 @@ Prepend the changelog with this template on every release.
 -->
 
 ## [Unreleased]
-- Moved artifact publishing from JCenter to Maven Central ()
+- Moved artifact publishing from JCenter to Maven Central (#81)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+<!--
+
+Prepend the changelog with this template on every release.
+
+# [Unreleased]
+- Changes (<PR #>)
+
+-->
+
+## [Unreleased]
+- Moved artifact publishing from JCenter to Maven Central ()

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -12,7 +12,6 @@ We currently deploy to Maven Central (via Sonatype's OSS Nexus instance).
 
 1. A *published* GPG code-signing key
 1. A Sonatype Nexus OSS account with permission to publish in com.getkeepsafe
-1. A plugins.gradle.org account with permission to publish in com.getkeepsafe
 1. Permission to push directly to https://github.com/KeepSafe/ReLinker
 
 ### Setup

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,72 @@
+How To Release
+==============
+
+Due to Maven Central's very particular requirements, the release process is a bit
+elaborate and requires a good deal of local configuration.  This guide should walk
+you through it.  It won't do anyone outside of KeepSafe any good, but the workflow
+is representative of just about any project deploying via Sonatype.
+
+We currently deploy to Maven Central (via Sonatype's OSS Nexus instance).
+
+### Prerequisites
+
+1. A *published* GPG code-signing key
+1. A Sonatype Nexus OSS account with permission to publish in com.getkeepsafe
+1. A plugins.gradle.org account with permission to publish in com.getkeepsafe
+1. Permission to push directly to https://github.com/KeepSafe/ReLinker
+
+### Setup
+
+1. Add your GPG key to your github profile - this is required
+   for github to know that your commits and tags are "verified".
+1. Configure your code-signing key in ~/.gradle.properties:
+   ```gradle
+   signing.keyId=<key ID of your GPG signing key>
+   signing.password=<your key's passphrase>
+   signing.secretKeyRingFile=/path/to/your/secring.gpg
+   ```
+1. Configure your Sonatype credentials in ~/.gradle.properties:
+   ```gradle
+   SONATYPE_NEXUS_USERNAME=<nexus username>
+   SONATYPE_NEXUS_PASSWORD=<nexus password>
+   ```
+1. Configure git with your codesigning key; make sure it's the same as the one
+   you use to sign binaries (i.e. it's the same one you added to gradle.properties):
+   ```bash
+   # Do this for the ReLinker repo only
+   git config user.email "your@email.com"
+   git config user.signingKey "your-key-id"
+   ```
+
+### Pushing a build
+
+1. Edit gradle.properties, update the VERSION property for the new version release
+1. Edit readme so that Gradle examples point to the new version
+1. Edit changelog, add relevant changes, note the date and new version (follow the existing pattern)
+1. Add new `## [Unreleased]` header for next release
+1. Verify that the everything works:
+   ```bash
+   ./gradlew clean check
+   ```
+1. Make a *signed* commit:
+   ```bash
+   git commit -S -m "Release version X.Y.Z"
+   ```
+1. Make a *signed* tag ()check existing tags for message format):
+   ```bash
+   git tag -S -a X.Y.Z
+   ```
+1. Upload binaries to Sonatype:
+   ```bash
+   ./gradlew publish
+   ```
+1. Go to oss.sonatype.org, log in with your credentials
+1. Click "Staging Repositories"
+1. Find the "comgetkeepsafe" repo, usually at the bottom of the list
+1. "Close" the repository (select it then click the "close" button up top), the text field doesn't matter so put whatever you want in it
+1. Wait until that's done
+1. "Release" the repository, leave the checkbox checked.  Hooray, we're in Maven Central now!
+1. Push all of our work to Github to make it official:
+   ```bash
+   git push --tags origin master
+   ```

--- a/build.gradle
+++ b/build.gradle
@@ -15,6 +15,9 @@ allprojects {
     repositories {
         google()
         mavenCentral()
+        // TODO: Remove this repository when Android build tools no longer transitively pulls
+        //  `trove4j` or if it's properly published in Maven Central when JCenter goes away.
+        //  See: https://github.com/KeepSafe/ReLinker/pull/81#issuecomment-787525670
         gradlePluginPortal()
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,19 +1,21 @@
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
+        gradlePluginPortal()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.2.1'
+        classpath 'com.android.tools.build:gradle:4.1.2'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
-        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4'
+        classpath 'com.vanniktech:gradle-maven-publish-plugin:0.13.0'
     }
 }
 
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
+        gradlePluginPortal()
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,24 @@
-android.useDeprecatedNdk=true
+android.useAndroidX=true
+
+GROUP=com.getkeepsafe.relinker
+VERSION_NAME=1.4.2
+POM_ARTIFACT_ID=relinker
+
+POM_NAME=ReLinker
+POM_PACKAGING=aar
+
+POM_DESCRIPTION=A robust native library loader for Android
+POM_INCEPTION_YEAR=2015
+
+POM_URL=https://github.com/KeepSafe/ReLinker
+POM_SCM_URL=https://github.com/KeepSafe/ReLinker
+POM_SCM_CONNECTION=scm:git:git://github.com/KeepSafe/ReLinker.git
+POM_SCM_DEV_CONNECTION=scm:git:ssh://git@github.com:KeepSafe/ReLinker.git
+
+POM_LICENCE_NAME=The Apache Software License, Version 2.0
+POM_LICENCE_URL=http://www.apache.org/licenses/LICENSE-2.0.txt
+POM_LICENCE_DIST=repo
+
+POM_DEVELOPER_ID=keepsafe
+POM_DEVELOPER_NAME=KeepSafe Software, Inc.
+POM_DEVELOPER_URL=https://github.com/KeepSafe/

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip

--- a/relinker/build.gradle
+++ b/relinker/build.gradle
@@ -1,9 +1,6 @@
 apply plugin: 'com.android.library'
 apply plugin: 'com.github.dcendents.android-maven'
-apply plugin: 'com.jfrog.bintray'
-
-group = 'com.getkeepsafe.relinker'
-version = '1.4.1'
+apply plugin: 'com.vanniktech.maven.publish'
 
 android {
     compileSdkVersion 28
@@ -36,59 +33,6 @@ dependencies {
     testImplementation 'org.hamcrest:hamcrest-all:1.3'
 }
 
-install {
-    repositories.mavenInstaller {
-        pom.project {
-            name 'ReLinker'
-            description 'A robust native library loader for Android'
-            url 'https://github.com/KeepSafe/ReLinker'
-            inceptionYear 2015
-
-            packaging 'aar'
-            groupId project.group
-            artifactId 'relinker'
-            version project.version
-
-            licenses {
-                license {
-                    name 'The Apache Software License, Version 2.0'
-                    url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
-                    distribution 'repo'
-                }
-            }
-            scm {
-                connection 'https://github.com/KeepSafe/ReLinker.git'
-                url 'https://github.com/KeepSafe/ReLinker'
-            }
-            developers {
-                developer {
-                    name 'KeepSafe'
-                }
-            }
-        }
-    }
-}
-
-bintray {
-    user = project.hasProperty('bintray.user') ? project.property('bintray.user') : ''
-    key = project.hasProperty('bintray.apikey') ? project.property('bintray.apikey') : ''
-    configurations = ['archives']
-    pkg {
-        repo = 'Android'
-        name = 'ReLinker'
-        userOrg = 'keepsafesoftware'
-        licenses = ['Apache-2.0']
-        vcsUrl = 'https://github.com/KeepSafe/ReLinker.git'
-
-        version {
-            name = project.version
-            desc = 'A robust native library loader for Android'
-            released = new Date()
-            vcsTag = project.version
-        }
-    }
-}
-
 // build a jar with source files
 task sourcesJar(type: Jar) {
     from android.sourceSets.main.java.srcDirs
@@ -110,4 +54,30 @@ task javadocJar(type: Jar, dependsOn: javadoc) {
 artifacts {
     archives sourcesJar
     archives javadocJar
+}
+
+def getGpgKey() {
+    return hasProperty("signingKey") ? signingKey : ""
+}
+
+def getGpgPassword() {
+    return hasProperty("signingKeyPassword") ? signingKeyPassword : ""
+}
+
+mavenPublish {
+    releaseSigningEnabled = !getGpgKey().isEmpty() && !getGpgPassword().isEmpty()
+    targets {
+        testMaven {
+            releaseRepositoryUrl = file("${rootProject.buildDir}/localMaven").toURI().toString()
+            snapshotRepositoryUrl = file("${rootProject.buildDir}/localMaven").toURI().toString()
+        }
+    }
+}
+
+signing {
+    def signingKey = getGpgKey()
+    def password = getGpgPassword()
+    if (!signingKey.isEmpty() && !password.isEmpty()) {
+        useInMemoryPgpKeys(signingKey, password)
+    }
 }

--- a/relinker/build.gradle
+++ b/relinker/build.gradle
@@ -55,29 +55,3 @@ artifacts {
     archives sourcesJar
     archives javadocJar
 }
-
-def getGpgKey() {
-    return hasProperty("signingKey") ? signingKey : ""
-}
-
-def getGpgPassword() {
-    return hasProperty("signingKeyPassword") ? signingKeyPassword : ""
-}
-
-mavenPublish {
-    releaseSigningEnabled = !getGpgKey().isEmpty() && !getGpgPassword().isEmpty()
-    targets {
-        testMaven {
-            releaseRepositoryUrl = file("${rootProject.buildDir}/localMaven").toURI().toString()
-            snapshotRepositoryUrl = file("${rootProject.buildDir}/localMaven").toURI().toString()
-        }
-    }
-}
-
-signing {
-    def signingKey = getGpgKey()
-    def password = getGpgPassword()
-    if (!signingKey.isEmpty() && !password.isEmpty()) {
-        useInMemoryPgpKeys(signingKey, password)
-    }
-}


### PR DESCRIPTION
This PR addresses https://github.com/KeepSafe/ReLinker/issues/79 and https://github.com/KeepSafe/ReLinker/issues/60.

Changes:
* Move artifact publishing from JCenter to Maven Central (Based on PR https://github.com/KeepSafe/ReLinker/pull/80)
* Added `CHANGELOG.md` file
* Added `RELEASING.md` guide for Keepsafe employees (Based from https://github.com/KeepSafe/dexcount-gradle-plugin/blob/master/RELEASING.md)

I published version `1.4.2` in https://repo1.maven.org/maven2/com/getkeepsafe/relinker/relinker/ based from this PR while testing the publishing process and ensuring credentials configurations work.

I'll publish another version `1.4.3` to have everything tagged and update the `README` page.

Thanks to:
* @tthiagomartinho, @benjamin-bader, @barnhill

