### PR TITLE
Update dependencies, target latest framework

### DIFF
--- a/relinker/build.gradle
+++ b/relinker/build.gradle
@@ -3,11 +3,10 @@ apply plugin: 'com.github.dcendents.android-maven'
 apply plugin: 'com.vanniktech.maven.publish'
 
 android {
-    compileSdkVersion 28
-    buildToolsVersion "28.0.3"
+    compileSdkVersion 30
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_6
-        targetCompatibility JavaVersion.VERSION_1_6
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
     }
 
     defaultConfig {
@@ -27,8 +26,8 @@ android {
 }
 
 dependencies {
-    testImplementation "org.robolectric:robolectric:4.0.2"
-    testImplementation 'junit:junit:4.12'
+    testImplementation "org.robolectric:robolectric:4.5.1"
+    testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.mockito:mockito-all:1.10.19'
     testImplementation 'org.hamcrest:hamcrest-all:1.3'
 }

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -5,8 +5,7 @@ repositories {
 }
 
 android {
-    compileSdkVersion 28
-    buildToolsVersion "28.0.3"
+    compileSdkVersion 30
 
     sourceSets {
         main {
@@ -18,7 +17,7 @@ android {
         applicationId "com.getkeepsafe.relinker.sample"
         //noinspection MinSdkTooLow
         minSdkVersion 9
-        targetSdkVersion 28
+        targetSdkVersion 30
         versionCode 1
         versionName "1.0"
     }
@@ -31,7 +30,7 @@ android {
 }
 
 dependencies {
-    compile project(':relinker')
-    testCompile 'junit:junit:4.12'
+    implementation project(':relinker')
+    testImplementation 'junit:junit:4.13.2'
 }
 


### PR DESCRIPTION
Updates to the latest of the dependencies at the time of this PR.  Also removes the use of build tools that are now incorporated into the gradle plugin by default.