### PR TITLE
Fix incorrect dangling Javadoc used for license, Javadoc errors, address lint warnings

### DIFF
--- a/relinker/src/main/java/com/getkeepsafe/relinker/ApkLibraryInstaller.java
+++ b/relinker/src/main/java/com/getkeepsafe/relinker/ApkLibraryInstaller.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 - 2016 KeepSafe Software, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,6 +15,7 @@
  */
 package com.getkeepsafe.relinker;
 
+import android.annotation.SuppressLint;
 import android.content.Context;
 import android.content.pm.ApplicationInfo;
 import android.os.Build;
@@ -148,6 +149,7 @@ public class ApkLibraryInstaller implements ReLinker.LibraryInstaller {
      * @param context {@link Context} to describe the location of the installed APK file
      * @param mappedLibraryName The mapped name of the library file to load
      */
+    @SuppressLint ("SetWorldReadable")
     @SuppressWarnings("ResultOfMethodCallIgnored")
     @Override
     public void installLibrary(final Context context,

--- a/relinker/src/main/java/com/getkeepsafe/relinker/MissingLibraryException.java
+++ b/relinker/src/main/java/com/getkeepsafe/relinker/MissingLibraryException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 - 2016 KeepSafe Software, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/relinker/src/main/java/com/getkeepsafe/relinker/ReLinker.java
+++ b/relinker/src/main/java/com/getkeepsafe/relinker/ReLinker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 - 2016 KeepSafe Software, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/relinker/src/main/java/com/getkeepsafe/relinker/ReLinkerInstance.java
+++ b/relinker/src/main/java/com/getkeepsafe/relinker/ReLinkerInstance.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 - 2016 KeepSafe Software, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -74,7 +74,7 @@ public class ReLinkerInstance {
     }
 
     /**
-     * Enables recursive library loading to resolve and load shared object -> shared object
+     * Enables recursive library loading to resolve and load shared object / shared object
      * defined dependencies
      */
     public ReLinkerInstance recursively() {

--- a/relinker/src/main/java/com/getkeepsafe/relinker/ReLinkerInstance.java
+++ b/relinker/src/main/java/com/getkeepsafe/relinker/ReLinkerInstance.java
@@ -74,7 +74,7 @@ public class ReLinkerInstance {
     }
 
     /**
-     * Enables recursive library loading to resolve and load shared object / shared object
+     * Enables recursive library loading to resolve and load shared object -&gt; shared object
      * defined dependencies
      */
     public ReLinkerInstance recursively() {

--- a/relinker/src/main/java/com/getkeepsafe/relinker/SystemLibraryLoader.java
+++ b/relinker/src/main/java/com/getkeepsafe/relinker/SystemLibraryLoader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 - 2016 KeepSafe Software, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,6 +15,7 @@
  */
 package com.getkeepsafe.relinker;
 
+import android.annotation.SuppressLint;
 import android.os.Build;
 
 @SuppressWarnings("deprecation")
@@ -24,6 +25,7 @@ final class SystemLibraryLoader implements ReLinker.LibraryLoader {
         System.loadLibrary(libraryName);
     }
 
+    @SuppressLint ("UnsafeDynamicallyLoadedCode")
     @Override
     public void loadPath(final String libraryPath) {
         System.load(libraryPath);

--- a/relinker/src/main/java/com/getkeepsafe/relinker/TextUtils.java
+++ b/relinker/src/main/java/com/getkeepsafe/relinker/TextUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 - 2016 KeepSafe Software, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -20,6 +20,9 @@ package com.getkeepsafe.relinker;
  * avoid depending on android.text.TextUtils.
  */
 final class TextUtils {
+    private TextUtils() {
+    }
+
     /**
      * Returns true if the string is null or 0-length.
      *


### PR DESCRIPTION
Summary:
This changes was part of another PR and was split out for clarity purposes.  It contains a few lint warning fixes and javadoc error fixes to improve the overall quality of the library.

Changes:
- Fix incorrect usage of Javadoc used for licenses at the top of source code files.
- Fix a couple javadoc errors that would fail to build javadoc correctly.
- Address 2 lint warnings that are calculated usages of methods that are either deprecated or cause a lint warning.