### PR TITLE
Remove reliance on JCenter

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:4.2.2'
-        classpath 'com.vanniktech:gradle-maven-publish-plugin:0.16.0'
+        classpath 'com.vanniktech:gradle-maven-publish-plugin:0.17.0'
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,17 +1,15 @@
 wrapper {
-    gradleVersion = '6.8.3'
+    gradleVersion = '7.1.1'
     distributionType = Wrapper.DistributionType.BIN
 }
 buildscript {
     repositories {
         google()
         mavenCentral()
-        gradlePluginPortal()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.2'
-        classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
-        classpath 'com.vanniktech:gradle-maven-publish-plugin:0.13.0'
+        classpath 'com.android.tools.build:gradle:4.2.2'
+        classpath 'com.vanniktech:gradle-maven-publish-plugin:0.16.0'
     }
 }
 
@@ -19,10 +17,6 @@ allprojects {
     repositories {
         google()
         mavenCentral()
-        // TODO: Remove this repository when Android build tools no longer transitively pulls
-        //  `trove4j` or if it's properly published in Maven Central when JCenter goes away.
-        //  See: https://github.com/KeepSafe/ReLinker/pull/81#issuecomment-787525670
-        gradlePluginPortal()
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,7 +13,7 @@ POM_INCEPTION_YEAR=2015
 POM_URL=https://github.com/KeepSafe/ReLinker
 POM_SCM_URL=https://github.com/KeepSafe/ReLinker
 POM_SCM_CONNECTION=scm:git:git://github.com/KeepSafe/ReLinker.git
-POM_SCM_DEV_CONNECTION=scm:git:ssh://git@github.com:KeepSafe/ReLinker.git
+POM_SCM_DEV_CONNECTION=scm:git:ssh://git@github.com/KeepSafe/ReLinker.git
 
 POM_LICENCE_NAME=The Apache Software License, Version 2.0
 POM_LICENCE_URL=http://www.apache.org/licenses/LICENSE-2.0.txt

--- a/gradlew
+++ b/gradlew
@@ -72,7 +72,7 @@ case "`uname`" in
   Darwin* )
     darwin=true
     ;;
-  MINGW* )
+  MSYS* | MINGW* )
     msys=true
     ;;
   NONSTOP* )

--- a/relinker/build.gradle
+++ b/relinker/build.gradle
@@ -1,5 +1,4 @@
 apply plugin: 'com.android.library'
-apply plugin: 'com.github.dcendents.android-maven'
 apply plugin: 'com.vanniktech.maven.publish'
 
 android {


### PR DESCRIPTION
This PR removes the reliance on JCenter. (https://github.com/KeepSafe/ReLinker/issues/86)  The usage of `gradlePluginPortal()` caused the dependency but was required for `trove4j`.  This was done knowingly at the time in https://github.com/KeepSafe/ReLinker/issues/79.  Now that `trove4j` is available on `mavenCentral` this can be removed.

Dependencies are also updated here since they were behind and the bump in gradle versions also deprecates the usage of JCenter and all references to it.