### PR TITLE
Include report of unscannable files in MissingLibraryException

### DIFF
--- a/relinker/src/main/java/com/getkeepsafe/relinker/AbiSupportInfo.java
+++ b/relinker/src/main/java/com/getkeepsafe/relinker/AbiSupportInfo.java
@@ -2,19 +2,20 @@ package com.getkeepsafe.relinker;
 
 import java.io.File;
 import java.util.Collections;
+import java.util.Map;
 import java.util.Set;
 
 public class AbiSupportInfo {
     private final Set<String> supportedAbis;
-    private final Set<File> unScannableFiles;
+    private final Map<File, Exception> unScannableFileAndReasons;
 
     public AbiSupportInfo(Set<String> supportedAbis) {
-        this(supportedAbis, Collections.emptySet());
+        this(supportedAbis, Collections.emptyMap());
     }
 
-    public AbiSupportInfo(Set<String> supportedAbis, Set<File> unscannableFiles) {
+    public AbiSupportInfo(Set<String> supportedAbis, Map<File, Exception> unscannableFilesAndReasons) {
         this.supportedAbis = supportedAbis;
-        this.unScannableFiles = unscannableFiles;
+        this.unScannableFileAndReasons = unscannableFilesAndReasons;
     }
 
     public String[] getSupportedAbis() {
@@ -23,11 +24,11 @@ public class AbiSupportInfo {
         return arr;
     }
 
-    public String[] getUnscannableFileNames() {
-        String[] arr = new String[unScannableFiles.size()];
+    public String[] getUnscannableFileNameAndReasons() {
+        String[] arr = new String[unScannableFileAndReasons.size()];
         int i = 0;
-        for (File file : unScannableFiles) {
-            arr[i++] = file.getName();
+        for (Map.Entry<File, Exception> entry : unScannableFileAndReasons.entrySet()) {
+            arr[i++] = entry.getKey().getName() + " => " + entry.getValue();
         }
         return arr;
     }

--- a/relinker/src/main/java/com/getkeepsafe/relinker/AbiSupportInfo.java
+++ b/relinker/src/main/java/com/getkeepsafe/relinker/AbiSupportInfo.java
@@ -1,0 +1,34 @@
+package com.getkeepsafe.relinker;
+
+import java.io.File;
+import java.util.Collections;
+import java.util.Set;
+
+public class AbiSupportInfo {
+    private final Set<String> supportedAbis;
+    private final Set<File> unScannableFiles;
+
+    public AbiSupportInfo(Set<String> supportedAbis) {
+        this(supportedAbis, Collections.emptySet());
+    }
+
+    public AbiSupportInfo(Set<String> supportedAbis, Set<File> unscannableFiles) {
+        this.supportedAbis = supportedAbis;
+        this.unScannableFiles = unscannableFiles;
+    }
+
+    public String[] getSupportedAbis() {
+        String[] arr = new String[supportedAbis.size()];
+        supportedAbis.toArray(arr);
+        return arr;
+    }
+
+    public String[] getUnscannableFileNames() {
+        String[] arr = new String[unScannableFiles.size()];
+        int i = 0;
+        for (File file : unScannableFiles) {
+            arr[i++] = file.getName();
+        }
+        return arr;
+    }
+}

--- a/relinker/src/main/java/com/getkeepsafe/relinker/ActualZipFileFactory.java
+++ b/relinker/src/main/java/com/getkeepsafe/relinker/ActualZipFileFactory.java
@@ -1,0 +1,12 @@
+package com.getkeepsafe.relinker;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.zip.ZipFile;
+
+public class ActualZipFileFactory implements ZipFileFactory {
+    @Override
+    public ZipFile create(File file, int openMode) throws IOException {
+        return new ZipFile(file, openMode);
+    }
+}

--- a/relinker/src/main/java/com/getkeepsafe/relinker/ApkLibraryInstaller.java
+++ b/relinker/src/main/java/com/getkeepsafe/relinker/ApkLibraryInstaller.java
@@ -39,6 +39,16 @@ public class ApkLibraryInstaller implements ReLinker.LibraryInstaller {
     private static final int MAX_TRIES = 5;
     private static final int COPY_BUFFER_SIZE = 4096;
 
+    private final ZipFileFactory zipFileFactory;
+
+    ApkLibraryInstaller() {
+        this(new ActualZipFileFactory());
+    }
+
+    ApkLibraryInstaller(ZipFileFactory zipFileFactory) {
+        this.zipFileFactory = zipFileFactory;
+    }
+
     private String[] sourceDirectories(final Context context) {
         final ApplicationInfo appInfo = context.getApplicationInfo();
 
@@ -74,7 +84,7 @@ public class ApkLibraryInstaller implements ReLinker.LibraryInstaller {
             int tries = 0;
             while (tries++ < MAX_TRIES) {
                 try {
-                    zipFile = new ZipFile(new File(sourceDir), ZipFile.OPEN_READ);
+                    zipFile = zipFileFactory.create(new File(sourceDir), ZipFile.OPEN_READ);
                     break;
                 } catch (IOException ignored) {
                 }
@@ -123,7 +133,7 @@ public class ApkLibraryInstaller implements ReLinker.LibraryInstaller {
         Set<String> supportedABIs = new HashSet<String>();
         for (String sourceDir : sourceDirectories(context)) {
             try {
-                zipFile = new ZipFile(new File(sourceDir), ZipFile.OPEN_READ);
+                zipFile = zipFileFactory.create(new File(sourceDir), ZipFile.OPEN_READ);
             } catch (IOException ignored) {
                 continue;
             }

--- a/relinker/src/main/java/com/getkeepsafe/relinker/ApkLibraryInstaller.java
+++ b/relinker/src/main/java/com/getkeepsafe/relinker/ApkLibraryInstaller.java
@@ -29,7 +29,9 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.Collections;
 import java.util.Enumeration;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -132,13 +134,13 @@ public class ApkLibraryInstaller implements ReLinker.LibraryInstaller {
         Pattern pattern = Pattern.compile(p);
         ZipFile zipFile;
         Set<String> supportedABIs = new HashSet<String>();
-        Set<File> unscannableFiles = new HashSet<File>();
+        Map<File, Exception> unscannableFiles = new HashMap<File, Exception>();
         for (String sourceDir : sourceDirectories(context)) {
             File source = new File(sourceDir);
             try {
                 zipFile = zipFileFactory.create(source, ZipFile.OPEN_READ);
-            } catch (IOException ignored) {
-                unscannableFiles.add(source);
+            } catch (IOException e) {
+                unscannableFiles.put(source, e);
                 continue;
             }
 

--- a/relinker/src/main/java/com/getkeepsafe/relinker/MissingLibraryException.java
+++ b/relinker/src/main/java/com/getkeepsafe/relinker/MissingLibraryException.java
@@ -35,7 +35,7 @@ public class MissingLibraryException extends RuntimeException {
         sb.append("Looked for: ").append(Arrays.toString(wantedABIs)).append(", ");
         sb.append("but only found: ").append(Arrays.toString(abiSupportInfo.getSupportedAbis())).append(".");
 
-        String[] unscannableFileNames = abiSupportInfo.getUnscannableFileNames();
+        String[] unscannableFileNames = abiSupportInfo.getUnscannableFileNameAndReasons();
         if (unscannableFileNames.length != 0) {
             sb.append(" Additionally, encountered errors while scanning: ").append(Arrays.toString(unscannableFileNames)).append(".");
         }

--- a/relinker/src/main/java/com/getkeepsafe/relinker/MissingLibraryException.java
+++ b/relinker/src/main/java/com/getkeepsafe/relinker/MissingLibraryException.java
@@ -18,9 +18,28 @@ package com.getkeepsafe.relinker;
 import java.util.Arrays;
 
 public class MissingLibraryException extends RuntimeException {
-    public MissingLibraryException(final String library, final String[] wantedABIs, final String[] supportedABIs) {
-        super("Could not find '" + library + "'. " +
-                "Looked for: " + Arrays.toString(wantedABIs) + ", " +
-                "but only found: " + Arrays.toString(supportedABIs) + ".");
+    private final String library;
+    private final String[] wantedABIs;
+    private final AbiSupportInfo abiSupportInfo;
+
+    public MissingLibraryException(String library, String[] wantedABIs, AbiSupportInfo abiSupportInfo) {
+        this.library = library;
+        this.wantedABIs = wantedABIs;
+        this.abiSupportInfo = abiSupportInfo;
+    }
+
+    @Override
+    public String getMessage() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("Could not find '").append(library).append("'. ");
+        sb.append("Looked for: ").append(Arrays.toString(wantedABIs)).append(", ");
+        sb.append("but only found: ").append(Arrays.toString(abiSupportInfo.getSupportedAbis())).append(".");
+
+        String[] unscannableFileNames = abiSupportInfo.getUnscannableFileNames();
+        if (unscannableFileNames.length != 0) {
+            sb.append(" Additionally, encountered errors while scanning: ").append(Arrays.toString(unscannableFileNames)).append(".");
+        }
+
+        return sb.toString();
     }
 }

--- a/relinker/src/main/java/com/getkeepsafe/relinker/ZipFileFactory.java
+++ b/relinker/src/main/java/com/getkeepsafe/relinker/ZipFileFactory.java
@@ -1,0 +1,9 @@
+package com.getkeepsafe.relinker;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.zip.ZipFile;
+
+public interface ZipFileFactory {
+    ZipFile create(File file, int openMode) throws IOException;
+}

--- a/relinker/src/test/java/com/getkeepsafe/relinker/ApkLibraryInstallerTest.java
+++ b/relinker/src/test/java/com/getkeepsafe/relinker/ApkLibraryInstallerTest.java
@@ -80,6 +80,25 @@ public class ApkLibraryInstallerTest {
         }
     }
 
+    @Test
+    public void throwsMissingLibraryExceptionWhenABIIsMissingAndThereWereUnscannableDirs() throws IOException {
+        final Context context = mock(Context.class);
+        final ApplicationInfo appInfo = mock(ApplicationInfo.class);
+        final ReLinkerInstance instance = mock(ReLinkerInstance.class);
+        final ApkLibraryInstaller installer = new ApkLibraryInstaller(new FaultyZipFileFactory());
+        final File destination = tempFolder.newFile("test");
+        final String[] abis = new String[] {"armeabi-v7a"}; // For unit test running on a developer machine this is normally x86
+
+        when(context.getApplicationInfo()).thenReturn(appInfo);
+        appInfo.sourceDir = getClass().getResource("/fake.apk").getFile();
+
+        try {
+            installer.installLibrary(context, abis, "libtest.so", destination, instance);
+        } catch (MissingLibraryException e) {
+            assertEquals("Could not find 'libtest.so'. Looked for: [armeabi-v7a], but only found: []. Additionally, encountered errors while scanning: [fake.apk].", e.getMessage());
+        }
+    }
+
     private String fileToString(final File file) throws IOException {
         final long size = file.length();
         if (size > Integer.MAX_VALUE) {

--- a/relinker/src/test/java/com/getkeepsafe/relinker/ApkLibraryInstallerTest.java
+++ b/relinker/src/test/java/com/getkeepsafe/relinker/ApkLibraryInstallerTest.java
@@ -95,7 +95,7 @@ public class ApkLibraryInstallerTest {
         try {
             installer.installLibrary(context, abis, "libtest.so", destination, instance);
         } catch (MissingLibraryException e) {
-            assertEquals("Could not find 'libtest.so'. Looked for: [armeabi-v7a], but only found: []. Additionally, encountered errors while scanning: [fake.apk].", e.getMessage());
+            assertEquals("Could not find 'libtest.so'. Looked for: [armeabi-v7a], but only found: []. Additionally, encountered errors while scanning: [fake.apk => java.io.IOException: Could not create zip file.].", e.getMessage());
         }
     }
 

--- a/relinker/src/test/java/com/getkeepsafe/relinker/FaultyZipFileFactory.java
+++ b/relinker/src/test/java/com/getkeepsafe/relinker/FaultyZipFileFactory.java
@@ -1,0 +1,12 @@
+package com.getkeepsafe.relinker;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.zip.ZipFile;
+
+public class FaultyZipFileFactory implements ZipFileFactory {
+    @Override
+    public ZipFile create(File file, int openMode) throws IOException {
+        throw new IOException("Could not create zip file.");
+    }
+}


### PR DESCRIPTION
### What has changed

To reduce ambiguity, we would want to report unscannable files whenever we're querying for `getSupportedABIs()`. This is done by:

1. Employing an object which could store problematic `File`s information in addition to the supported ABIs.
2. Modifying `getSupportedABIs()`'s catch clause to capture said information.
3. Modifying `MissingLibraryException` to report it.

Additionally, to ease testing, refactor `ZipFile` factory logic out from `ApkLibraryInstaller` so we can mock this scenario.

#### Sample exception message post this change

```
Could not find 'libtest.so'. Looked for: [armeabi-v7a], but only found: []. Additionally, encountered errors while scanning: [fake.apk => java.io.IOException: Could not create zip file.].
```

### Why it was changed

As an attempt to resolve #107.